### PR TITLE
Stop cache manager when disabling the plugin

### DIFF
--- a/lib/rabbitmq_message_deduplication/cache_manager.ex
+++ b/lib/rabbitmq_message_deduplication/cache_manager.ex
@@ -26,6 +26,7 @@ defmodule RabbitMQMessageDeduplication.CacheManager do
     __MODULE__,
     [description: "message deduplication plugin cache maintenance process",
      mfa: {:rabbit_sup, :start_child, [__MODULE__]},
+     cleanup: {:rabbit_sup, :stop_child, [__MODULE__]},
      requires: :database,
      enables: :external_infrastructure]}
 

--- a/test/exchange_SUITE.erl
+++ b/test/exchange_SUITE.erl
@@ -21,6 +21,7 @@ all() ->
 groups() ->
     [
      {non_parallel_tests, [], [
+                               disable_enable,
                                declare_exchanges,
                                deduplicate_message,
                                deduplicate_message_ttl,
@@ -64,6 +65,11 @@ end_per_testcase(Testcase, Config) ->
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
+
+%% Basic smoke test that it is possible to disable, then enable the plugin
+disable_enable(Config) ->
+    ok = rabbit_ct_broker_helpers:disable_plugin(Config, 0, rabbitmq_message_deduplication),
+    ok = rabbit_ct_broker_helpers:enable_plugin(Config, 0, rabbitmq_message_deduplication).
 
 declare_exchanges(Config) ->
     Channel = rabbit_ct_client_helpers:open_channel(Config),


### PR DESCRIPTION
This prevents enabling after disabling from failing with:

```
(CaseClauseError) no case clause matching: {:badrpc, {:EXIT, {:error, {:already_started, #PID<11988.1602.0>}}}}
```