### PR TITLE
Correct statement about dropping older entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To create a message deduplication exchange, just declare it providing the type `
 
 Required arguments:
 
-  * `x-cache-size`: maximum number of entries for the deduplication cache. If the deduplication cache fills up, random entries will be removed to give space to new ones.
+  * `x-cache-size`: maximum number of entries for the deduplication cache. If the deduplication cache fills up, unspecified existing entries will be removed to give space to new ones.
 
 Optional arguments:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To create a message deduplication exchange, just declare it providing the type `
 
 Required arguments:
 
-  * `x-cache-size`: maximum number of entries for the deduplication cache. If the deduplication cache fills up, older entries will be removed to give space to new ones.
+  * `x-cache-size`: maximum number of entries for the deduplication cache. If the deduplication cache fills up, random entries will be removed to give space to new ones.
 
 Optional arguments:
 


### PR DESCRIPTION
Previously the README stated that older entries were removed. The actual behaviour is that an unspecified element is removed from the set.[[1]](https://github.com/noxdafox/rabbitmq-message-deduplication/blob/b16790554b83811052c8417e8dc3548ed1d0d4d2/lib/rabbitmq_message_deduplication/cache.ex#L214)
