### PR TITLE
Fix typo of Mnesia storage_type

### DIFF
--- a/lib/rabbitmq_message_deduplication/cache.ex
+++ b/lib/rabbitmq_message_deduplication/cache.ex
@@ -273,8 +273,8 @@ defmodule RabbitMQMessageDeduplication.Cache do
   # Returns a tuple {persistence, nodes}
   defp cache_layout(cache) do
     case Mnesia.table_info(cache, :ram_copies) do
-      [] -> {:disc_nodes, Mnesia.table_info(cache, :disc_copies)}
-      nodes -> {:ram_nodes, nodes}
+      [] -> {:disc_copies, Mnesia.table_info(cache, :disc_copies)}
+      nodes -> {:ram_copies, nodes}
     end
   end
 


### PR DESCRIPTION
Plugin used to crash in a distributed cluster when a node was added to the cache replicas because `Mnesia.add_table_copy/3` was called with invalid table storage type argument.

```
node 'rabbit@node-02' up
** Generic server 'Elixir.RabbitMQMessageDeduplication.CacheManager' terminating
** Last message in was {mnesia_system_event,
                           {mnesia_up,'rabbit@node-02'}}
** When Server state == #{}
** Reason for termination ==
** {{case_clause,
        {aborted,
            {badarg,cache_exchange_<name>,
                ram_nodes}}},
    [{'Elixir.RabbitMQMessageDeduplication.Cache',
         '-cache_rebalance/1-fun-0-',4,
```