### PR TITLE
Support message containers introduced in RabbitMQ 3.13.0

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -10,7 +10,7 @@ jobs:
         elixir:
           - '1.16.3'
         rmqref:
-          - v3.12.x
+          - v3.13.x
     steps:
       - uses: actions/checkout@v4
       - name: Install Erlang and Elixir

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PROJECT = rabbitmq_message_deduplication
+PROJ_VSN = $(shell $(MIX) eval 'Mix.Project.config()[:version] |> IO.puts()')
 
 DEPS = rabbit_common rabbit
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client
@@ -25,15 +26,15 @@ app:: $(elixir_srcs) deps
 
 dist:: app
 	mkdir -p $(DIST_DIR)
-	$(MIX) make_archives
+	$(MIX) archive.build.elixir
+	$(MIX) archive.build -o $(DIST_DIR)/$(PROJECT)-$(PROJ_VSN).ez
 	cp -r _build/$(MIX_ENV)/archives/elixir-*.ez $(DIST_DIR)
-	cp -r _build/$(MIX_ENV)/archives/$(PROJECT)-*.ez $(DIST_DIR)
 
 test-build:: app
 	mkdir -p $(DIST_DIR)
-	$(MIX) make_archives
+	$(MIX) archive.build.elixir
+	$(MIX) archive.build -o $(DIST_DIR)/$(PROJECT)-$(PROJ_VSN).ez
 	cp -r _build/$(MIX_ENV)/archives/elixir-*.ez $(DIST_DIR)
-	cp -r _build/$(MIX_ENV)/archives/$(PROJECT)-*.ez $(DIST_DIR)
 
 tests:: $(elixir_srcs) deps
 	MIX_ENV=test $(MIX) make_tests

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Then copy all the *.ez files inside the plugins folder to the [RabbitMQ plugins 
     [sudo] rabbitmq-plugins enable rabbitmq_message_deduplication
 ```
 
+## Version requirements
+
+The latest version of the plugin requires RabbitMQ 3.13.0.
+
+Earlier RabbitMQ versions are supported by 0.6.2.
+
 ## Exchange level deduplication
 
 The exchange type `x-message-deduplication` allows to filter message duplicates before any routing rule is applied.

--- a/lib/rabbitmq_message_deduplication/rabbit_message_deduplication_exchange.ex
+++ b/lib/rabbitmq_message_deduplication/rabbit_message_deduplication_exchange.ex
@@ -53,12 +53,6 @@ defmodule RabbitMQMessageDeduplication.Exchange do
   defrecord :exchange, extract(
     :exchange, from_lib: "rabbit_common/include/rabbit.hrl")
 
-  defrecord :delivery, extract(
-    :delivery, from_lib: "rabbit_common/include/rabbit.hrl")
-
-  defrecord :basic_message, extract(
-    :basic_message, from_lib: "rabbit_common/include/rabbit.hrl")
-
   @doc """
   Register the exchange type within the Broker.
   """
@@ -90,7 +84,7 @@ defmodule RabbitMQMessageDeduplication.Exchange do
   end
 
   @impl :rabbit_exchange_type
-  def route(exchange(name: name), delivery(message: msg = basic_message())) do
+  def route(exchange(name: name), msg, _opts) do
     if route?(name, msg) do
       RabbitRouter.match_routing_key(name, [:_])
     else

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,8 @@ defmodule RabbitMQ.MessageDeduplicationPlugin.Mixfile do
       applications: [:mnesia],
       extra_applications: [:rabbit],
       mod: {RabbitMQMessageDeduplication, []},
-      registered: [RabbitMQMessageDeduplication]
+      registered: [RabbitMQMessageDeduplication],
+      broker_version_requirements: ["3.13.0"]
     ]
   end
 


### PR DESCRIPTION
This commit makes the plugin depend on the `mc` module and hence 3.13.0+ at runtime.

Fixes #108